### PR TITLE
V9.0.0/net9rc1 alembic

### DIFF
--- a/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
@@ -5,6 +5,12 @@ Availability: .NET 9, .NET 8 and .NET Standard 2.0
 - CHANGED Dependencies to latest and greatest with respect to TFMs
 - REMOVED Support for TFM .NET 6 (LTS)
  
+# Breaking Changes
+- REMOVED AddXunitTestLogging method (the overload that took an ITestOutputHelperAccessor argument) from the ServiceCollectionExtensions class in the Codebelt.Extensions.Xunit.Hosting namespace
+ 
+# Improvements
+- CHANGED AddXunitTestLogging method in the Codebelt.Extensions.Xunit.Hosting namespace to use an ILoggerProvider that utilizes either the ITestOutputHelper instance or a previously provided ITestOutputHelperAccessor service
+ 
 Version 8.4.1
 Availability: .NET 8, .NET 6 and .NET Standard 2.0
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ This major release is first and foremost focused on ironing out any wrinkles tha
     }
     ```
 
+### Changed
+
+- AddXunitTestLogging method in the Codebelt.Extensions.Xunit.Hosting namespace to use an ILoggerProvider that utilizes either the ITestOutputHelper instance or a previously provided ITestOutputHelperAccessor service
+
+### Removed
+
+- AddXunitTestLogging method (the overload that took an ITestOutputHelperAccessor argument) from the ServiceCollectionExtensions class in the Codebelt.Extensions.Xunit.Hosting namespace
+
 ## [8.4.1] - 2024-09-16
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -84,6 +84,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.5" PrivateAssets="all" />
     <ProjectReference Include="..\..\src\Codebelt.Extensions.Xunit\Codebelt.Extensions.Xunit.csproj" />
   </ItemGroup>
 

--- a/src/Codebelt.Extensions.Xunit.Hosting.AspNetCore/Codebelt.Extensions.Xunit.Hosting.AspNetCore.csproj
+++ b/src/Codebelt.Extensions.Xunit.Hosting.AspNetCore/Codebelt.Extensions.Xunit.Hosting.AspNetCore.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.Extensions.DependencyInjection" Version="9.0.0-preview.5" />
-    <PackageReference Include="Cuemon.IO" Version="9.0.0-preview.5" />
+    <PackageReference Include="Cuemon.Extensions.DependencyInjection" Version="9.0.0-preview.5" PrivateAssets="all" />
+    <PackageReference Include="Cuemon.IO" Version="9.0.0-preview.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Codebelt.Extensions.Xunit.Hosting/Codebelt.Extensions.Xunit.Hosting.csproj
+++ b/src/Codebelt.Extensions.Xunit.Hosting/Codebelt.Extensions.Xunit.Hosting.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.5" PrivateAssets="all" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.0" />
   </ItemGroup>
 

--- a/src/Codebelt.Extensions.Xunit.Hosting/LoggerExtensions.cs
+++ b/src/Codebelt.Extensions.Xunit.Hosting/LoggerExtensions.cs
@@ -2,9 +2,7 @@
 using System.Collections;
 using System.Linq;
 using Cuemon;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Codebelt.Extensions.Xunit.Hosting
 {
@@ -14,7 +12,7 @@ namespace Codebelt.Extensions.Xunit.Hosting
     public static class LoggerExtensions
     {
         /// <summary>
-        /// Returns the associated <see cref="ITestStore{T}"/> that is provided when settings up services from either <see cref="ServiceCollectionExtensions.AddXunitTestLogging(IServiceCollection,ITestOutputHelper,LogLevel)"/> or <see cref="ServiceCollectionExtensions.AddXunitTestLogging(IServiceCollection,ITestOutputHelperAccessor,LogLevel)"/>.
+        /// Returns the associated <see cref="ITestStore{T}"/> that is provided when settings up services from <see cref="ServiceCollectionExtensions.AddXunitTestLogging"/>.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger{TCategoryName}"/> from which to retrieve the <see cref="ITestStore{T}"/>.</param>
         /// <returns>Returns an implementation of <see cref="ITestStore{T}"/> with all logged entries expressed as <see cref="XunitTestLoggerEntry"/>.</returns>

--- a/src/Codebelt.Extensions.Xunit.Hosting/ServiceCollectionExtensions.cs
+++ b/src/Codebelt.Extensions.Xunit.Hosting/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Cuemon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -21,39 +22,33 @@ namespace Codebelt.Extensions.Xunit.Hosting
         /// <exception cref="ArgumentNullException"> 
         /// <paramref name="services"/> cannot be null -or- 
         /// <paramref name="output"/> cannot be null. 
-        /// </exception> 
+        /// </exception>
+        /// <remarks>This method will add a xUnit logger provider based on either <see cref="ITestOutputHelper"/> or <see cref="ITestOutputHelperAccessor"/>.</remarks>
         public static IServiceCollection AddXunitTestLogging(this IServiceCollection services, ITestOutputHelper output, LogLevel minimumLevel = LogLevel.Trace) 
         { 
             Validator.ThrowIfNull(services); 
-            Validator.ThrowIfNull(output); 
-            services.AddLogging(builder => 
-            { 
-                builder.SetMinimumLevel(minimumLevel); 
-                builder.AddProvider(new XunitTestLoggerProvider(output)); 
-            }); 
-            return services; 
-        } 
-        
-        /// <summary> 
-        /// Adds a unit test optimized implementation of output logging to the <paramref name="services"/> collection. 
-        /// </summary> 
-        /// <param name="services">The <see cref="IServiceCollection"/> to extend.</param> 
-        /// <param name="accessor">The <see cref="ITestOutputHelperAccessor"/> that provides access to the output for the logging.</param> 
-        /// <param name="minimumLevel">The <see cref="LogLevel"/> that specifies the minimum level to include for the logging.</param> 
-        /// <returns>A reference to <paramref name="services" /> so that additional configuration calls can be chained.</returns> 
-        /// <exception cref="ArgumentNullException"> 
-        /// <paramref name="services"/> cannot be null -or- 
-        /// <paramref name="accessor"/> cannot be null. 
-        /// </exception> 
-        public static IServiceCollection AddXunitTestLogging(this IServiceCollection services, ITestOutputHelperAccessor accessor, LogLevel minimumLevel = LogLevel.Trace) 
-        { 
-            Validator.ThrowIfNull(services); 
-            Validator.ThrowIfNull(accessor);
-            services.AddLogging(builder => 
-            { 
-                builder.SetMinimumLevel(minimumLevel); 
-                builder.AddProvider(new XunitTestLoggerProvider(accessor)); 
-            }); 
+            Validator.ThrowIfNull(output);
+            if (services.Any(d => d.ServiceType == typeof(ITestOutputHelperAccessor)))
+            {
+                services.AddLogging(builder => 
+                { 
+                    builder.SetMinimumLevel(minimumLevel); 
+                    builder.Services.AddSingleton<ILoggerProvider>(provider =>
+                    {
+                        var accessor = provider.GetRequiredService<ITestOutputHelperAccessor>();
+                        accessor.TestOutput = output;
+                        return new XunitTestLoggerProvider(accessor);
+                    });
+                });
+            }
+            else
+            {
+                services.AddLogging(builder => 
+                { 
+                    builder.SetMinimumLevel(minimumLevel); 
+                    builder.AddProvider(new XunitTestLoggerProvider(output)); 
+                });
+            }
             return services; 
         } 
 

--- a/src/Codebelt.Extensions.Xunit/Codebelt.Extensions.Xunit.csproj
+++ b/src/Codebelt.Extensions.Xunit/Codebelt.Extensions.Xunit.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.5" />
+    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.5" PrivateAssets="all" />
     <PackageReference Include="xunit.assert" Version="2.9.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>

--- a/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/AspNetCoreHostTestTest.cs
+++ b/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/AspNetCoreHostTestTest.cs
@@ -78,7 +78,7 @@ namespace Codebelt.Extensions.Xunit.Hosting.AspNetCore
                 o.E = true;
             });
             services.AddXunitTestLoggingOutputHelperAccessor();
-            services.AddXunitTestLogging(new TestOutputHelperAccessor(TestOutput));
+            services.AddXunitTestLogging(TestOutput);
         }
     }
 }

--- a/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/MvcAspNetCoreHostTestTest.cs
+++ b/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/MvcAspNetCoreHostTestTest.cs
@@ -46,7 +46,7 @@ namespace Codebelt.Extensions.Xunit.Hosting.AspNetCore
                 .AddApplicationPart(typeof(FakeController).Assembly);
 
             services.AddXunitTestLoggingOutputHelperAccessor();
-            services.AddXunitTestLogging(new TestOutputHelperAccessor(TestOutput));
+            services.AddXunitTestLogging(TestOutput);
         }
 
         public override void ConfigureApplication(IApplicationBuilder app)


### PR DESCRIPTION
#### PR Classification
API change and dependency update.

#### PR Summary
This PR introduces a breaking change by modifying the `AddXunitTestLogging` method and updates dependencies.
- `ServiceCollectionExtensions.cs`: Removed `AddXunitTestLogging` method with `ITestOutputHelperAccessor` and modified the remaining method,
- `LoggerExtensions.cs`: Updated to reflect changes in `AddXunitTestLogging` method,
- `PackageReleaseNotes.txt` and `CHANGELOG.md`: Updated to document changes and dependency updates,
- `Codebelt.Extensions.Xunit.csproj` and related project files: Updated to include `Cuemon.*` version `9.0.0-preview.5` as a private asset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced logging functionality in the Xunit testing framework.
	- Simplified logging configuration by consolidating methods.

- **Breaking Changes**
	- Removed the overload of `AddXunitTestLogging` that accepted `ITestOutputHelperAccessor`.
	- Dropped support for .NET 6; now compatible with .NET 8, .NET 9, and .NET Standard 2.0.

- **Improvements**
	- Introduced `ILoggerProvider` for more flexible logging options.
	- Updated documentation for clarity and simplicity.

- **Chores**
	- Added `Cuemon.Core` package reference to enhance test project functionality while keeping dependencies private.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->