### PR TITLE
:recycle: better DX with less cognitive load for AddXunitTestLogging

### DIFF
--- a/src/Codebelt.Extensions.Xunit.Hosting/LoggerExtensions.cs
+++ b/src/Codebelt.Extensions.Xunit.Hosting/LoggerExtensions.cs
@@ -2,9 +2,7 @@
 using System.Collections;
 using System.Linq;
 using Cuemon;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Codebelt.Extensions.Xunit.Hosting
 {
@@ -14,7 +12,7 @@ namespace Codebelt.Extensions.Xunit.Hosting
     public static class LoggerExtensions
     {
         /// <summary>
-        /// Returns the associated <see cref="ITestStore{T}"/> that is provided when settings up services from either <see cref="ServiceCollectionExtensions.AddXunitTestLogging(IServiceCollection,ITestOutputHelper,LogLevel)"/> or <see cref="ServiceCollectionExtensions.AddXunitTestLogging(IServiceCollection,ITestOutputHelperAccessor,LogLevel)"/>.
+        /// Returns the associated <see cref="ITestStore{T}"/> that is provided when settings up services from <see cref="ServiceCollectionExtensions.AddXunitTestLogging"/>.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger{TCategoryName}"/> from which to retrieve the <see cref="ITestStore{T}"/>.</param>
         /// <returns>Returns an implementation of <see cref="ITestStore{T}"/> with all logged entries expressed as <see cref="XunitTestLoggerEntry"/>.</returns>

--- a/src/Codebelt.Extensions.Xunit.Hosting/ServiceCollectionExtensions.cs
+++ b/src/Codebelt.Extensions.Xunit.Hosting/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Cuemon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -25,38 +26,31 @@ namespace Codebelt.Extensions.Xunit.Hosting
         public static IServiceCollection AddXunitTestLogging(this IServiceCollection services, ITestOutputHelper output, LogLevel minimumLevel = LogLevel.Trace) 
         { 
             Validator.ThrowIfNull(services); 
-            Validator.ThrowIfNull(output); 
-            services.AddLogging(builder => 
-            { 
-                builder.SetMinimumLevel(minimumLevel); 
-                builder.AddProvider(new XunitTestLoggerProvider(output)); 
-            }); 
+            Validator.ThrowIfNull(output);
+            if (services.Any(sd => sd.ServiceType == typeof(ITestOutputHelperAccessor)))
+            {
+                services.AddLogging(builder => 
+                { 
+                    builder.SetMinimumLevel(minimumLevel);
+                    builder.Services.AddSingleton<ILoggerProvider>(provider =>
+                    {
+                        var accessor = provider.GetRequiredService<ITestOutputHelperAccessor>();
+                        accessor.TestOutput = output;
+                        return new XunitTestLoggerProvider(accessor);
+                    });
+                }); 
+            }
+            else
+            {
+                services.AddLogging(builder => 
+                { 
+                    builder.SetMinimumLevel(minimumLevel); 
+                    builder.AddProvider(new XunitTestLoggerProvider(output)); 
+                }); 
+            }
             return services; 
         } 
         
-        /// <summary> 
-        /// Adds a unit test optimized implementation of output logging to the <paramref name="services"/> collection. 
-        /// </summary> 
-        /// <param name="services">The <see cref="IServiceCollection"/> to extend.</param> 
-        /// <param name="accessor">The <see cref="ITestOutputHelperAccessor"/> that provides access to the output for the logging.</param> 
-        /// <param name="minimumLevel">The <see cref="LogLevel"/> that specifies the minimum level to include for the logging.</param> 
-        /// <returns>A reference to <paramref name="services" /> so that additional configuration calls can be chained.</returns> 
-        /// <exception cref="ArgumentNullException"> 
-        /// <paramref name="services"/> cannot be null -or- 
-        /// <paramref name="accessor"/> cannot be null. 
-        /// </exception> 
-        public static IServiceCollection AddXunitTestLogging(this IServiceCollection services, ITestOutputHelperAccessor accessor, LogLevel minimumLevel = LogLevel.Trace) 
-        { 
-            Validator.ThrowIfNull(services); 
-            Validator.ThrowIfNull(accessor);
-            services.AddLogging(builder => 
-            { 
-                builder.SetMinimumLevel(minimumLevel); 
-                builder.AddProvider(new XunitTestLoggerProvider(accessor)); 
-            }); 
-            return services; 
-        } 
-
         /// <summary>
         /// Adds a default implementation of <see cref="ITestOutputHelperAccessor"/> to the <paramref name="services"/> collection.
         /// </summary>

--- a/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/AspNetCoreHostTestTest.cs
+++ b/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/AspNetCoreHostTestTest.cs
@@ -78,7 +78,7 @@ namespace Codebelt.Extensions.Xunit.Hosting.AspNetCore
                 o.E = true;
             });
             services.AddXunitTestLoggingOutputHelperAccessor();
-            services.AddXunitTestLogging(new TestOutputHelperAccessor(TestOutput));
+            services.AddXunitTestLogging(TestOutput);
         }
     }
 }

--- a/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/MvcAspNetCoreHostTestTest.cs
+++ b/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/MvcAspNetCoreHostTestTest.cs
@@ -46,7 +46,7 @@ namespace Codebelt.Extensions.Xunit.Hosting.AspNetCore
                 .AddApplicationPart(typeof(FakeController).Assembly);
 
             services.AddXunitTestLoggingOutputHelperAccessor();
-            services.AddXunitTestLogging(new TestOutputHelperAccessor(TestOutput));
+            services.AddXunitTestLogging(TestOutput);
         }
 
         public override void ConfigureApplication(IApplicationBuilder app)


### PR DESCRIPTION
#### PR Classification
Code cleanup and refactoring to improve logging configuration and remove redundancies.

#### PR Summary
Refactored logging configuration and removed unused directives to streamline code and improve maintainability.
- `LoggerExtensions.cs`: Removed unused `using` directives and simplified XML documentation.
- `ServiceCollectionExtensions.cs`: Added `System.Linq` directive, refactored `AddXunitTestLogging` method, and removed an overloaded method.
- `AspNetCoreHostTestTest.cs` and `MvcAspNetCoreHostTestTest.cs`: Updated calls to `AddXunitTestLogging` to use the simplified method signature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified logging configuration by removing the `ITestOutputHelperAccessor`, allowing direct use of `ITestOutputHelper` in the logging setup.
- **Bug Fixes**
	- Updated method documentation for clarity and conciseness.
- **Tests**
	- Adjusted test cases to reflect the new logging method signature, enhancing the clarity of logging setup in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->