### PR TITLE
V9.0.0/netstandard2.0 support replacelineendings

### DIFF
--- a/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
@@ -5,6 +5,9 @@ Availability: .NET 9, .NET 8 and .NET Standard 2.0
 - CHANGED Dependencies to latest and greatest with respect to TFMs
 - REMOVED Support for TFM .NET 6 (LTS)
  
+# Breaking Changes
+- REMOVED AddXunitTestLogging overloaded extension method from the ServiceCollectionExtensions class in the Codebelt.Extensions.Xunit.Hosting namespace
+ 
 Version 8.4.1
 Availability: .NET 8, .NET 6 and .NET Standard 2.0
  

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting/README.md
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting/README.md
@@ -39,7 +39,7 @@ public class AspNetCoreHostTestTest : AspNetCoreHostTest<AspNetCoreHostFixture>
     public override void ConfigureServices(IServiceCollection services)
     {
         services.AddXunitTestLoggingOutputHelperAccessor();
-        services.AddXunitTestLogging(new TestOutputHelperAccessor(TestOutput));
+        services.AddXunitTestLogging(TestOutput);
     }
 }
 ```

--- a/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
@@ -17,6 +17,7 @@ Availability: .NET 8, .NET 6 and .NET Standard 2.0
 # New Features
 - ADDED ITestOutputHelperAccessor interface in the Codebelt.Extensions.Xunit namespace that provides access to the ITestOutputHelper instance
 - ADDED TestOutputHelperAccessor class in the Codebelt.Extensions.Xunit namespace that provides a default implementation of the ITestOutputHelper interface
+- ADDED StringExtensions class in the Codebelt.Extensions.Xunit namespace with one extension method (TFM netstandard2.0) for the String class: ReplaceLineEndings
  
 Version 8.3.2
 Availability: .NET 8, .NET 6 and .NET Standard 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 
 This major release is first and foremost focused on ironing out any wrinkles that have been introduced with .NET 9 preview releases so the final release is production ready together with the official launch from Microsoft.
 
+### Added
+
+- StringExtensions class in the Codebelt.Extensions.Xunit namespace with one extension method (TFM netstandard2.0) for the String class: ReplaceLineEndings
+
+### Removed
+
+- AddXunitTestLogging overloaded extension method from the ServiceCollectionExtensions class in the Codebelt.Extensions.Xunit.Hosting namespace (breaking)
+
 ### Fixed
 
 - AspNetCoreHostFixture class in the Codebelt.Extensions.Xunit.Hosting.AspNetCore namespace to preserve ExecutionContext and AsyncLocal{T} values from the client to the server (vital for ITestOutputHelperAccessor combined with xUnit test logging when using HttpClient)

--- a/src/Codebelt.Extensions.Xunit/StringExtensions.cs
+++ b/src/Codebelt.Extensions.Xunit/StringExtensions.cs
@@ -1,0 +1,45 @@
+﻿#if NETSTANDARD2_0_OR_GREATER
+using System;
+using System.Text.RegularExpressions;
+using Cuemon;
+
+namespace Codebelt.Extensions.Xunit
+{
+    /// <summary>
+    /// Extension methods for the <see cref="string" /> class.
+    /// </summary>
+    public static class StringExtensions
+    {
+        private static readonly Regex NewLineRegex = new(@"\r\n|\r|\n", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Replaces all newline sequences in the current string with <see cref="Environment.NewLine"/>.
+        /// </summary>
+        /// <param name="input">The <see cref="string"/> to extend.</param>
+        /// <returns>A string whose contents match the current string, but with all newline sequences replaced with <see cref="Environment.NewLine"/>.</returns>
+        /// <remarks>Shamefully stolen from https://github.com/WebFormsCore/WebFormsCore/blob/main/src/WebFormsCore/Util/StringExtensions.cs to support .NET Standard 2.0.</remarks>
+        public static string ReplaceLineEndings(this string input)
+        {
+            return ReplaceLineEndings(input, Environment.NewLine);
+        }
+
+        /// <summary>
+        /// Replaces all newline sequences in the current string with <paramref name="replacementText"/>.
+        /// </summary>
+        /// <param name="input">The <see cref="string"/> to extend.</param>
+        /// <param name="replacementText">The text to use as replacement.</param>
+        /// <returns>A string whose contents match the current string, but with all newline sequences replaced with <paramref name="replacementText"/>.</returns>
+        /// <remarks>Shamefully stolen from https://github.com/WebFormsCore/WebFormsCore/blob/main/src/WebFormsCore/Util/StringExtensions.cs to support .NET Standard 2.0.</remarks>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> cannot be null -or-
+        /// <paramref name="replacementText"/> cannot be null.
+        /// </exception>
+        public static string ReplaceLineEndings(this string input, string replacementText)
+        {
+            Validator.ThrowIfNull(input);
+            Validator.ThrowIfNull(replacementText);
+            return NewLineRegex.Replace(input, replacementText);
+        }
+    }
+}
+#endif

--- a/test/Codebelt.Extensions.Xunit.Tests/StringExtensionsTest.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/StringExtensionsTest.cs
@@ -1,0 +1,36 @@
+﻿using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Codebelt.Extensions.Xunit
+{
+    public class StringExtensionsTest : Test
+    {
+        public StringExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void ReplaceLineEndings_ShouldReplaceNewLineOccurrences()
+        {
+            var lineEndings = "Windows has \r\n (CRLF) and Linux has \n (LF)";
+
+            TestOutput.WriteLine($$"""
+                                   Before: {{lineEndings}}
+                                   After: {{lineEndings.ReplaceLineEndings()}}
+                                   """);
+
+            TestOutput.WriteLine(RuntimeInformation.OSDescription);
+            TestOutput.WriteLine(RuntimeInformation.FrameworkDescription);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Assert.Equal("Windows has \n (CRLF) and Linux has \n (LF)", lineEndings.ReplaceLineEndings());
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Equal("Windows has \r\n (CRLF) and Linux has \r\n (LF)", lineEndings.ReplaceLineEndings());
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### PR Classification
New feature: Introduces extension methods for the `string` class to handle newline sequences.

#### PR Summary
Adds new extension methods to the `string` class for replacing newline sequences and corresponding unit tests.
- `StringExtensions.cs`: Adds `ReplaceLineEndings` methods for replacing newline sequences with `Environment.NewLine` or custom text.
- `StringExtensionsTest.cs`: Adds unit tests using `Xunit` to verify the functionality of `ReplaceLineEndings` methods across different operating systems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced extension methods for the `string` class to replace newline sequences with the system's newline representation or a custom text.
- **Tests**
	- Added a test class to validate the functionality of the new string extension methods, ensuring correct handling of various newline formats based on the operating system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->