### PR TITLE
V9.0.0/housekeeping and cuemon aid

### DIFF
--- a/.docfx/api/namespaces/Codebelt.Extensions.Xunit.md
+++ b/.docfx/api/namespaces/Codebelt.Extensions.Xunit.md
@@ -13,3 +13,4 @@ Complements: [xUnit: Capturing Output](https://xunit.net/docs/capturing-output) 
 |Type|Ext|Methods|
 |--:|:-:|---|
 |ITestOutputHelper|⬇️|`WriteLines`|
+|String|⬇️|`ReplaceLineEndings` (TFM netstandard2.0)|

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -70,8 +70,8 @@
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Codebelt.Extensions.Xunit.Hosting.AspNetCore/Codebelt.Extensions.Xunit.Hosting.AspNetCore.csproj
+++ b/src/Codebelt.Extensions.Xunit.Hosting.AspNetCore/Codebelt.Extensions.Xunit.Hosting.AspNetCore.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.Extensions.DependencyInjection" Version="9.0.0-preview.8" />
-    <PackageReference Include="Cuemon.IO" Version="9.0.0-preview.8" />
+    <PackageReference Include="Cuemon.Extensions.DependencyInjection" Version="9.0.0-preview.9" />
+    <PackageReference Include="Cuemon.IO" Version="9.0.0-preview.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Codebelt.Extensions.Xunit.Hosting/Codebelt.Extensions.Xunit.Hosting.csproj
+++ b/src/Codebelt.Extensions.Xunit.Hosting/Codebelt.Extensions.Xunit.Hosting.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.extensibility.core" Version="2.9.1" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Codebelt.Extensions.Xunit/Codebelt.Extensions.Xunit.csproj
+++ b/src/Codebelt.Extensions.Xunit/Codebelt.Extensions.Xunit.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Description>The Cuemon.Extensions.Xunit namespace contains types that provides a uniform way of doing unit testing. The namespace relates to the Xunit.Abstractions namespace.</Description>
+    <Description>The Codebelt.Extensions.Xunit namespace contains types that provides a uniform way of doing unit testing. The namespace relates to the Xunit.Abstractions namespace.</Description>
     <PackageTags>test test-output test-disposable test-cleanup</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.8" />
-    <PackageReference Include="xunit.assert" Version="2.9.1" />
+    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.9" />
+    <PackageReference Include="xunit.assert" Version="2.9.2" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Codebelt.Extensions.Xunit/GlobalSuppressions.cs
+++ b/src/Codebelt.Extensions.Xunit/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Major Code Smell", "S3881:\"IDisposable\" should be implemented correctly", Justification = "This is a base class implementation of the IDisposable interface tailored to avoid wrong implementations.", Scope = "type", Target = "~T:Codebelt.Extensions.Xunit.Test")]

--- a/src/Codebelt.Extensions.Xunit/Test.cs
+++ b/src/Codebelt.Extensions.Xunit/Test.cs
@@ -9,9 +9,8 @@ namespace Codebelt.Extensions.Xunit
     /// <summary>
     /// Represents the base class from which all implementations of unit testing should derive.
     /// </summary>
-    /// <seealso cref="Disposable"/>
     /// <seealso cref="ITestOutputHelper"/>
-    public abstract class Test : Disposable, ITest
+    public abstract class Test : ITest
     {
         /// <summary>
         /// Provides a way, with wildcard support, to determine if <paramref name="actual" /> matches <paramref name="expected" />.
@@ -71,10 +70,47 @@ namespace Codebelt.Extensions.Xunit
         protected bool HasTestOutput => TestOutput != null;
 
         /// <summary>
-        /// Called when this object is being disposed by either <see cref="M:Cuemon.Disposable.Dispose" /> or <see cref="M:Cuemon.Disposable.Dispose(System.Boolean)" /> having <c>disposing</c> set to <c>true</c> and <see cref="P:Cuemon.Disposable.Disposed" /> is <c>false</c>.
+        /// Gets a value indicating whether this <see cref="Disposable"/> object is disposed.
         /// </summary>
-        protected override void OnDisposeManagedResources()
+        /// <value><c>true</c> if this <see cref="Disposable"/> object is disposed; otherwise, <c>false</c>.</value>
+        public bool Disposed { get; private set; }
+
+        /// <summary>
+        /// Called when this object is being disposed by either <see cref="Dispose()" /> or <see cref="Dispose(bool)" /> having <c>disposing</c> set to <c>true</c> and <see cref="Disposed" /> is <c>false</c>.
+        /// </summary>
+        protected virtual void OnDisposeManagedResources()
         {
+        }
+
+        /// <summary>
+        /// Called when this object is being disposed by either <see cref="Dispose()"/> or <see cref="Dispose(bool)"/> and <see cref="Disposed"/> is <c>false</c>.
+        /// </summary>
+        protected virtual void OnDisposeUnmanagedResources()
+        {
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="Disposable"/> object.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the <see cref="Disposable"/> object and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected void Dispose(bool disposing)
+        {
+            if (Disposed) { return; }
+            if (disposing)
+            {
+                OnDisposeManagedResources();
+            }
+            OnDisposeUnmanagedResources();
+            Disposed = true;
         }
     }
 }

--- a/src/Codebelt.Extensions.Xunit/Test.cs
+++ b/src/Codebelt.Extensions.Xunit/Test.cs
@@ -70,9 +70,9 @@ namespace Codebelt.Extensions.Xunit
         protected bool HasTestOutput => TestOutput != null;
 
         /// <summary>
-        /// Gets a value indicating whether this <see cref="Disposable"/> object is disposed.
+        /// Gets a value indicating whether this <see cref="Test"/> object is disposed.
         /// </summary>
-        /// <value><c>true</c> if this <see cref="Disposable"/> object is disposed; otherwise, <c>false</c>.</value>
+        /// <value><c>true</c> if this <see cref="Test"/> object is disposed; otherwise, <c>false</c>.</value>
         public bool Disposed { get; private set; }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Codebelt.Extensions.Xunit
         }
 
         /// <summary>
-        /// Releases all resources used by the <see cref="Disposable"/> object.
+        /// Releases all resources used by the <see cref="Test"/> object.
         /// </summary>
         public void Dispose()
         {
@@ -99,7 +99,7 @@ namespace Codebelt.Extensions.Xunit
         }
 
         /// <summary>
-        /// Releases the unmanaged resources used by the <see cref="Disposable"/> object and optionally releases the managed resources.
+        /// Releases the unmanaged resources used by the <see cref="Test"/> object and optionally releases the managed resources.
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
         protected void Dispose(bool disposing)

--- a/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests.csproj
+++ b/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.AspNetCore" Version="9.0.0-preview.8" />
-    <PackageReference Include="Cuemon.Extensions.AspNetCore" Version="9.0.0-preview.8" />
-    <PackageReference Include="Cuemon.Extensions.IO" Version="9.0.0-preview.8" />
+    <PackageReference Include="Cuemon.AspNetCore" Version="9.0.0-preview.9" />
+    <PackageReference Include="Cuemon.Extensions.AspNetCore" Version="9.0.0-preview.9" />
+    <PackageReference Include="Cuemon.Extensions.IO" Version="9.0.0-preview.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Codebelt.Extensions.Xunit.Tests/Assets/ManagedDisposable.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/Assets/ManagedDisposable.cs
@@ -1,9 +1,8 @@
 ﻿using System.IO;
-using Cuemon;
 
 namespace Codebelt.Extensions.Xunit.Assets
 {
-    public class ManagedDisposable : Disposable
+    public class ManagedDisposable : Test
     {
         public ManagedDisposable()
         {

--- a/test/Codebelt.Extensions.Xunit.Tests/Assets/ManagedDisposable.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/Assets/ManagedDisposable.cs
@@ -1,0 +1,27 @@
+﻿using System.IO;
+using Cuemon;
+
+namespace Codebelt.Extensions.Xunit.Assets
+{
+    public class ManagedDisposable : Disposable
+    {
+        public ManagedDisposable()
+        {
+            Stream = new MemoryStream();
+        }
+
+        public MemoryStream Stream { get; private set; }
+
+        protected override void OnDisposeManagedResources()
+        {
+            try
+            {
+                Stream?.Dispose();
+            }
+            finally
+            {
+                Stream = null;
+            }
+        }
+    }
+}

--- a/test/Codebelt.Extensions.Xunit.Tests/Assets/UnmanagedDisposable.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/Assets/UnmanagedDisposable.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using Cuemon;
 #if NET48_OR_GREATER
 using NativeLibraryLoader;
 #endif
 namespace Codebelt.Extensions.Xunit.Assets
 {
-    public class UnmanagedDisposable : FinalizeDisposable
+    public class UnmanagedDisposable : Test
     {
         internal IntPtr _handle = IntPtr.Zero;
         internal IntPtr _libHandle = IntPtr.Zero;
@@ -30,7 +29,7 @@ namespace Codebelt.Extensions.Xunit.Assets
         public UnmanagedDisposable()
         {
 #if NET6_0_OR_GREATER
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (NativeLibrary.TryLoad("kernel32.dll", GetType().Assembly, DllImportSearchPath.System32, out _libHandle))
                 {
@@ -47,7 +46,7 @@ namespace Codebelt.Extensions.Xunit.Assets
                     }
                 }
             }
-            else if (Environment.OSVersion.Platform == PlatformID.Unix)
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 if (NativeLibrary.TryLoad("libc.so.6", GetType().Assembly, DllImportSearchPath.SafeDirectories, out _libHandle))
                 {
@@ -55,7 +54,7 @@ namespace Codebelt.Extensions.Xunit.Assets
                 }
             }
 #else
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 _nativeLibrary = new NativeLibrary("kernel32.dll");
                 _libHandle = _nativeLibrary.Handle;
@@ -69,7 +68,7 @@ namespace Codebelt.Extensions.Xunit.Assets
                     0,
                     IntPtr.Zero);
             }
-            else if (Environment.OSVersion.Platform == PlatformID.Unix)
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 _nativeLibrary = new NativeLibrary("libc.so.6");
                 _libHandle = _nativeLibrary.Handle;
@@ -77,6 +76,12 @@ namespace Codebelt.Extensions.Xunit.Assets
             }
 #endif
         }
+
+        ~UnmanagedDisposable()
+        {
+            Dispose(false);
+        }
+
 
         protected override void OnDisposeManagedResources()
         {
@@ -86,7 +91,7 @@ namespace Codebelt.Extensions.Xunit.Assets
         protected override void OnDisposeUnmanagedResources()
         {
 #if NET6_0_OR_GREATER
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (_handle != IntPtr.Zero)
                 {
@@ -98,12 +103,12 @@ namespace Codebelt.Extensions.Xunit.Assets
                 }
                 NativeLibrary.Free(_libHandle);
             }
-            else if (Environment.OSVersion.Platform == PlatformID.Unix)
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 NativeLibrary.Free(_libHandle);
             }
 #else
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (_handle != IntPtr.Zero)
                 {
@@ -113,7 +118,7 @@ namespace Codebelt.Extensions.Xunit.Assets
                 }
                 _nativeLibrary.Dispose();
             }
-            else if (Environment.OSVersion.Platform == PlatformID.Unix)
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 _nativeLibrary.Dispose();
             }

--- a/test/Codebelt.Extensions.Xunit.Tests/Assets/UnmanagedDisposable.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/Assets/UnmanagedDisposable.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Cuemon;
+#if NET48_OR_GREATER
+using NativeLibraryLoader;
+#endif
+namespace Codebelt.Extensions.Xunit.Assets
+{
+    public class UnmanagedDisposable : FinalizeDisposable
+    {
+        internal IntPtr _handle = IntPtr.Zero;
+        internal IntPtr _libHandle = IntPtr.Zero;
+
+        public delegate bool CloseHandle(IntPtr hObject);
+
+        public delegate IntPtr CreateFileDelegate(string lpFileName,
+            uint dwDesiredAccess,
+            uint dwShareMode,
+            IntPtr lpSecurityAttributes,
+            uint dwCreationDisposition,
+            uint dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        public delegate IntPtr PtSname(int fd);
+
+#if NET48_OR_GREATER
+        internal NativeLibrary _nativeLibrary;
+#endif
+
+        public UnmanagedDisposable()
+        {
+#if NET6_0_OR_GREATER
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                if (NativeLibrary.TryLoad("kernel32.dll", GetType().Assembly, DllImportSearchPath.System32, out _libHandle))
+                {
+                    if (NativeLibrary.TryGetExport(_libHandle, "CreateFileW", out var functionHandle))
+                    {
+                        var createFileFunc = Marshal.GetDelegateForFunctionPointer<CreateFileDelegate>(functionHandle);
+                        _handle = createFileFunc(@"C:\TestFile.txt",
+                            0x80000000, //access read-only
+                            1, //share-read
+                            IntPtr.Zero,
+                            3, //open existing
+                            0,
+                            IntPtr.Zero);
+                    }
+                }
+            }
+            else if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                if (NativeLibrary.TryLoad("libc.so.6", GetType().Assembly, DllImportSearchPath.SafeDirectories, out _libHandle))
+                {
+                    _handle = _libHandle; // i don't know of any native methods on unix
+                }
+            }
+#else
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                _nativeLibrary = new NativeLibrary("kernel32.dll");
+                _libHandle = _nativeLibrary.Handle;
+                var functionHandle = _nativeLibrary.LoadFunction("CreateFileW");
+                var createFileFunc = Marshal.GetDelegateForFunctionPointer<CreateFileDelegate>(functionHandle);
+                _handle = createFileFunc(@"C:\TestFile.txt",
+                    0x80000000, //access read-only
+                    1, //share-read
+                    IntPtr.Zero,
+                    3, //open existing
+                    0,
+                    IntPtr.Zero);
+            }
+            else if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                _nativeLibrary = new NativeLibrary("libc.so.6");
+                _libHandle = _nativeLibrary.Handle;
+                _handle = _libHandle; // i don't know of any native methods on unix
+            }
+#endif
+        }
+
+        protected override void OnDisposeManagedResources()
+        {
+
+        }
+
+        protected override void OnDisposeUnmanagedResources()
+        {
+#if NET6_0_OR_GREATER
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                if (_handle != IntPtr.Zero)
+                {
+                    if (NativeLibrary.TryGetExport(_libHandle, "CloseHandle", out var closeHandle))
+                    {
+                        var closeHandleAction = Marshal.GetDelegateForFunctionPointer<CloseHandle>(closeHandle);
+                        closeHandleAction(_handle);
+                    }
+                }
+                NativeLibrary.Free(_libHandle);
+            }
+            else if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                NativeLibrary.Free(_libHandle);
+            }
+#else
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                if (_handle != IntPtr.Zero)
+                {
+                    var closeHandle = _nativeLibrary.LoadFunction("CloseHandle");
+                    var closeHandleAction = Marshal.GetDelegateForFunctionPointer<CloseHandle>(closeHandle);
+                    closeHandleAction(_handle);
+                }
+                _nativeLibrary.Dispose();
+            }
+            else if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                _nativeLibrary.Dispose();
+            }
+#endif
+        }
+    }
+}

--- a/test/Codebelt.Extensions.Xunit.Tests/Codebelt.Extensions.Xunit.Tests.csproj
+++ b/test/Codebelt.Extensions.Xunit.Tests/Codebelt.Extensions.Xunit.Tests.csproj
@@ -4,4 +4,8 @@
     <RootNamespace>Codebelt.Extensions.Xunit</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NativeLibraryLoader" Version="1.0.13" />
+  </ItemGroup>
+
 </Project>

--- a/test/Codebelt.Extensions.Xunit.Tests/DisposableTest.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/DisposableTest.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Codebelt.Extensions.Xunit.Assets;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Codebelt.Extensions.Xunit
+{
+    public class DisposableTest : Test
+    {
+        public DisposableTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+
+
+        [Fact]
+        public void ManagedDisposable_VerifyThatAssetIsBeingDisposed()
+        {
+            ManagedDisposable mdRef = null;
+            using (var md = new ManagedDisposable())
+            {
+                mdRef = md;
+                Assert.NotNull(md.Stream);
+                Assert.Equal(0, md.Stream.Length);
+                Assert.False(mdRef.Disposed);
+            }
+            Assert.NotNull(mdRef);
+            Assert.Null(mdRef.Stream);
+            Assert.True(mdRef.Disposed);
+        }
+
+        private WeakReference<UnmanagedDisposable> unmanaged = null;
+
+        [Fact]
+        public void UnmanagedDisposable_VerifyThatAssetIsBeingDisposedOnFinalize()
+        {
+            Action body = () =>
+            {
+                var o = new UnmanagedDisposable();
+                Assert.NotEqual(IntPtr.Zero, o._libHandle);
+                Assert.NotEqual(IntPtr.Zero, o._handle);
+                unmanaged = new WeakReference<UnmanagedDisposable>(o, true);
+            };
+
+            try
+            {
+                body();
+            }
+            finally
+            {
+                GC.Collect(0, GCCollectionMode.Forced);
+                GC.WaitForPendingFinalizers();
+            }
+
+            if (unmanaged.TryGetTarget(out var ud2))
+            {
+                Assert.True(ud2.Disposed);
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### PR Classification
Code cleanup and new feature implementation.

#### PR Summary
This pull request updates package references and introduces ported disposal logic from [Disposable](https://github.com/gimlichael/Cuemon/blob/main/src/Cuemon.Core/Disposable.cs).
- `Directory.Build.props`, `Codebelt.Extensions.Xunit.Hosting.AspNetCore.csproj`, `Codebelt.Extensions.Xunit.Hosting.csproj`, `Codebelt.Extensions.Xunit.csproj`: Updated various package references,
- `Codebelt.Extensions.Xunit.md`: Added `ReplaceLineEndings` extension method for `String`,
- `Test.cs`: Refactored `Test` class to implement `IDisposable` directly with custom disposal logic incl. complementing unit tests.

The effort taken here is to reduce the risk of strange behaviors from Cuemon library due to both libraries depending on one another. Circular reference challenge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new extension method `ReplaceLineEndings` for the `String` type.
	- Added classes `ManagedDisposable` and `UnmanagedDisposable` for improved resource management.
	- New unit tests for verifying disposal behavior of managed and unmanaged resources.

- **Bug Fixes**
	- Updated package references to ensure compatibility and stability.

- **Documentation**
	- Updated documentation for the `Codebelt.Extensions.Xunit` namespace to reflect new features.

- **Chores**
	- Introduced a `GlobalSuppressions.cs` file for code analysis purposes.
	- Added `NativeLibraryLoader` package to enhance project capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->