### PR TITLE
V9.0.0/private assets experiment

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,8 +15,8 @@
 
   <Target Name="ApplyFileVersion" AfterTargets="MinVer">
     <PropertyGroup>
-      <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">00000</BUILD_BUILDNUMBER>
-      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BUILD_BUILDNUMBER)</FileVersion>
+      <GITHUB_RUN_NUMBER Condition="'$(GITHUB_RUN_NUMBER)' == ''">0</GITHUB_RUN_NUMBER>
+      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(GITHUB_RUN_NUMBER)</FileVersion>
     </PropertyGroup>
   </Target>
 

--- a/src/Codebelt.Extensions.Xunit.Hosting.AspNetCore/Codebelt.Extensions.Xunit.Hosting.AspNetCore.csproj
+++ b/src/Codebelt.Extensions.Xunit.Hosting.AspNetCore/Codebelt.Extensions.Xunit.Hosting.AspNetCore.csproj
@@ -24,8 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.Extensions.DependencyInjection" Version="9.0.0-preview.9" />
-    <PackageReference Include="Cuemon.IO" Version="9.0.0-preview.9" />
+    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.9" PrivateAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Codebelt.Extensions.Xunit.Hosting.AspNetCore/Http/FakeHttpContextAccessor.cs
+++ b/src/Codebelt.Extensions.Xunit.Hosting.AspNetCore/Http/FakeHttpContextAccessor.cs
@@ -1,5 +1,8 @@
-﻿using Codebelt.Extensions.Xunit.Hosting.AspNetCore.Http.Features;
-using Cuemon.IO;
+﻿using System;
+using System.IO;
+using System.Text;
+using Codebelt.Extensions.Xunit.Hosting.AspNetCore.Http.Features;
+using Cuemon;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 
@@ -20,8 +23,21 @@ namespace Codebelt.Extensions.Xunit.Hosting.AspNetCore.Http
             var fc = new FeatureCollection();
             fc.Set<IHttpResponseFeature>(new FakeHttpResponseFeature());
             fc.Set<IHttpRequestFeature>(new FakeHttpRequestFeature());
-            fc.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(StreamFactory.Create(writer => writer.Write("Hello awesome developers!"))));
+            fc.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(MakeGreeting("Hello awesome developers!")));
             HttpContext = new DefaultHttpContext(fc);
+        }
+
+        private Stream MakeGreeting(string greeting)
+        {
+            return Patterns.SafeInvoke(() => new MemoryStream(), ms =>
+            {
+                var sw = new StreamWriter(ms, Encoding.UTF8);
+                sw.Write(greeting);
+                sw.Flush();
+                ms.Flush();
+                ms.Position = 0;
+                return ms;
+            }, ex => throw new InvalidOperationException("There is an error in the Stream being written.", ex));
         }
 
         /// <summary>

--- a/src/Codebelt.Extensions.Xunit.Hosting/Codebelt.Extensions.Xunit.Hosting.csproj
+++ b/src/Codebelt.Extensions.Xunit.Hosting/Codebelt.Extensions.Xunit.Hosting.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.9" PrivateAssets="compile" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.2" />
   </ItemGroup>
 

--- a/src/Codebelt.Extensions.Xunit.Hosting/GlobalSuppressions.cs
+++ b/src/Codebelt.Extensions.Xunit.Hosting/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Major Code Smell", "S3881:\"IDisposable\" should be implemented correctly", Justification = "This is an implementation of the IDisposable interface tailored to avoid wrong implementations.", Scope = "type", Target = "~T:Codebelt.Extensions.Xunit.Hosting.HostFixture")]

--- a/src/Codebelt.Extensions.Xunit.Hosting/HostFixture.cs
+++ b/src/Codebelt.Extensions.Xunit.Hosting/HostFixture.cs
@@ -11,9 +11,8 @@ namespace Codebelt.Extensions.Xunit.Hosting
     /// <summary>
     /// Provides a default implementation of the <see cref="IHostFixture"/> interface.
     /// </summary>
-    /// <seealso cref="Disposable" />
     /// <seealso cref="IHostFixture" />
-    public class HostFixture : Disposable, IHostFixture
+    public class HostFixture : IDisposable, IHostFixture
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HostFixture"/> class.
@@ -127,15 +126,52 @@ namespace Codebelt.Extensions.Xunit.Hosting
 #endif
 
         /// <summary>
-        /// Called when this object is being disposed by either <see cref="M:Cuemon.Disposable.Dispose" /> or <see cref="M:Cuemon.Disposable.Dispose(System.Boolean)" /> having <c>disposing</c> set to <c>true</c> and <see cref="P:Cuemon.Disposable.Disposed" /> is <c>false</c>.
+        /// Gets a value indicating whether this <see cref="HostFixture"/> object is disposed.
         /// </summary>
-        protected override void OnDisposeManagedResources()
+        /// <value><c>true</c> if this <see cref="HostFixture"/> object is disposed; otherwise, <c>false</c>.</value>
+        public bool Disposed { get; private set; }
+
+        /// <summary>
+        /// Called when this object is being disposed by either <see cref="Dispose()" /> or <see cref="Dispose(bool)" /> having <c>disposing</c> set to <c>true</c> and <see cref="Disposed" /> is <c>false</c>.
+        /// </summary>
+        protected virtual void OnDisposeManagedResources()
         {
             if (ServiceProvider is ServiceProvider sp)
             {
                 sp.Dispose();
             }
             Host?.Dispose();
+        }
+
+        /// <summary>
+        /// Called when this object is being disposed by either <see cref="Dispose()"/> or <see cref="Dispose(bool)"/> and <see cref="Disposed"/> is <c>false</c>.
+        /// </summary>
+        protected virtual void OnDisposeUnmanagedResources()
+        {
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="HostFixture"/> object.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the <see cref="HostFixture"/> object and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected void Dispose(bool disposing)
+        {
+            if (Disposed) { return; }
+            if (disposing)
+            {
+                OnDisposeManagedResources();
+            }
+            OnDisposeUnmanagedResources();
+            Disposed = true;
         }
     }
 }

--- a/src/Codebelt.Extensions.Xunit/Codebelt.Extensions.Xunit.csproj
+++ b/src/Codebelt.Extensions.Xunit/Codebelt.Extensions.Xunit.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <ProjectGuid>0d0bdf91-e7c7-4cb4-a39d-e1a5374c5602</ProjectGuid>
+    <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -10,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.9" />
+    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.9" PrivateAssets="compile" />
     <PackageReference Include="xunit.assert" Version="2.9.2" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>

--- a/src/Codebelt.Extensions.Xunit/Test.cs
+++ b/src/Codebelt.Extensions.Xunit/Test.cs
@@ -66,7 +66,7 @@ namespace Codebelt.Extensions.Xunit
         /// <summary>
         /// Gets a value indicating whether <see cref="TestOutput"/> has a reference to an implementation of <see cref="ITestOutputHelper"/>.
         /// </summary>
-        /// <value><c>true</c> if this instance has has a reference to an implementation of <see cref="ITestOutputHelper"/>; otherwise, <c>false</c>.</value>
+        /// <value><c>true</c> if this instance has a reference to an implementation of <see cref="ITestOutputHelper"/>; otherwise, <c>false</c>.</value>
         protected bool HasTestOutput => TestOutput != null;
 
         /// <summary>

--- a/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests.csproj
+++ b/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.AspNetCore" Version="9.0.0-preview.9" />
     <PackageReference Include="Cuemon.Extensions.AspNetCore" Version="9.0.0-preview.9" />
     <PackageReference Include="Cuemon.Extensions.IO" Version="9.0.0-preview.9" />
   </ItemGroup>

--- a/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/ServiceCollectionExtensionsTest.cs
+++ b/test/Codebelt.Extensions.Xunit.Hosting.AspNetCore.Tests/ServiceCollectionExtensionsTest.cs
@@ -1,0 +1,46 @@
+﻿using System.ComponentModel;
+using Codebelt.Extensions.Xunit.Hosting.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Codebelt.Extensions.Xunit.Hosting.AspNetCore
+{
+    public class ServiceCollectionExtensionsTest : Test
+    {
+        public ServiceCollectionExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData(ServiceLifetime.Transient)]
+        [InlineData(ServiceLifetime.Scoped)]
+        [InlineData(ServiceLifetime.Singleton)]
+        public void AddFakeHttpContextAccessor_ShouldAddService(ServiceLifetime lifetime)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddFakeHttpContextAccessor(lifetime);
+            var serviceProvider = services.BuildServiceProvider();
+            var httpContextAccessor = serviceProvider.GetService<IHttpContextAccessor>();
+
+            // Assert
+            Assert.NotNull(httpContextAccessor);
+            Assert.IsType<FakeHttpContextAccessor>(httpContextAccessor);
+        }
+
+        [Fact]
+        public void AddFakeHttpContextAccessor_ShouldThrowInvalidEnumArgumentException_ForInvalidLifetime()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var invalidLifetime = (ServiceLifetime)999;
+
+            // Act & Assert
+            Assert.Throws<InvalidEnumArgumentException>(() => services.AddFakeHttpContextAccessor(invalidLifetime));
+        }
+    }
+}

--- a/test/Codebelt.Extensions.Xunit.Hosting.Tests/Codebelt.Extensions.Xunit.Hosting.Tests.csproj
+++ b/test/Codebelt.Extensions.Xunit.Hosting.Tests/Codebelt.Extensions.Xunit.Hosting.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cuemon.Core" Version="9.0.0-preview.9" />
     <PackageReference Include="Xunit.Priority" Version="1.1.6" />
   </ItemGroup>
 

--- a/test/Codebelt.Extensions.Xunit.Tests/Assets/UnmanagedDisposable.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/Assets/UnmanagedDisposable.cs
@@ -82,7 +82,6 @@ namespace Codebelt.Extensions.Xunit.Assets
             Dispose(false);
         }
 
-
         protected override void OnDisposeManagedResources()
         {
 


### PR DESCRIPTION
#### PR Classification
Code cleanup and dependency updates.

#### PR Summary
This pull request updates dependencies, refactors code for better resource management, and introduces new tests.
- `Directory.Build.targets`: Replaced `BUILD_BUILDNUMBER` with `GITHUB_RUN_NUMBER` for `FileVersion`,
- `ServiceCollectionExtensions.cs`: Refactored `IHttpContextAccessor` addition with a switch statement and factory method,
- `HostFixture.cs`: Implemented `IDisposable` directly and added resource disposal methods,
- Added `ServiceCollectionExtensionsTest` to test `AddFakeHttpContextAccessor` with different `ServiceLifetime` values,
- Updated package references in multiple `.csproj` files, including adding `PrivateAssets="compile"` to `Cuemon.Core`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property for specifying package release notes file location.
	- Added a test class to validate the functionality of the new HTTP context accessor method.
  
- **Bug Fixes**
	- Corrected grammatical error in XML documentation comments for the `HasTestOutput` property.

- **Documentation**
	- Updated comments and documentation in the `HostFixture` class to reflect changes in resource management.

- **Chores**
	- Removed obsolete package references and updated project files to include new dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->