### PR TITLE
:alien: reduce risk of implicit strong name fails in Cuemon

### DIFF
--- a/src/Codebelt.Extensions.Xunit/StringExtensions.cs
+++ b/src/Codebelt.Extensions.Xunit/StringExtensions.cs
@@ -1,7 +1,6 @@
 ﻿#if NETSTANDARD2_0_OR_GREATER
 using System;
 using System.Text.RegularExpressions;
-using Cuemon;
 
 namespace Codebelt.Extensions.Xunit
 {
@@ -36,8 +35,8 @@ namespace Codebelt.Extensions.Xunit
         /// </exception>
         public static string ReplaceLineEndings(this string input, string replacementText)
         {
-            Validator.ThrowIfNull(input);
-            Validator.ThrowIfNull(replacementText);
+            if (input == null) { throw new ArgumentNullException(nameof(input)); }
+            if (replacementText == null) { throw new ArgumentNullException(nameof(replacementText)); }
             return NewLineRegex.Replace(input, replacementText);
         }
     }

--- a/src/Codebelt.Extensions.Xunit/Test.cs
+++ b/src/Codebelt.Extensions.Xunit/Test.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Cuemon;
 using Xunit.Abstractions;
 
 namespace Codebelt.Extensions.Xunit
@@ -25,7 +24,8 @@ namespace Codebelt.Extensions.Xunit
         /// </exception>
         public static bool Match(string expected, string actual, Action<WildcardOptions> setup = null)
         {
-            Validator.ThrowIfInvalidConfigurator(setup, out var options);
+            var options = new WildcardOptions();
+            setup?.Invoke(options);
 
             var pattern = $"^{Regex.Escape(expected).Replace(options.SingleCharacter, ".").Replace(options.GroupOfCharacters, ".*")}$";
 

--- a/src/Codebelt.Extensions.Xunit/WildcardOptions.cs
+++ b/src/Codebelt.Extensions.Xunit/WildcardOptions.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using Cuemon.Configuration;
 
 namespace Codebelt.Extensions.Xunit
 {
     /// <summary>
     /// Configuration options for <see cref="Test.Match"/>.
     /// </summary>
-    public class WildcardOptions : IParameterObject
+    public class WildcardOptions
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="WildcardOptions"/> class.


### PR DESCRIPTION
#### PR Classification
Code cleanup to remove external dependency on the `Cuemon` library.

#### PR Summary
The changes eliminate the `Cuemon` library dependency by replacing it with standard .NET functionality.
- `StringExtensions.cs`: Replaced `Validator.ThrowIfNull` with `ArgumentNullException` checks,
- `Test.cs`: Replaced `Validator.ThrowIfInvalidConfigurator` with manual `WildcardOptions` initialization and optional `setup` action,
- `WildcardOptions.cs`: Removed `IParameterObject` interface implementation.

This is done due to Cuemon being a strong-named assembly and with dependency to this library clash occurs if build without strong name key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the `ReplaceLineEndings` method for improved clarity.
	- Simplified configuration for `WildcardOptions` in the `Match` method.

- **Bug Fixes**
	- Improved handling of null parameters in string manipulation methods.

- **Refactor**
	- Removed interface dependency from the `WildcardOptions` class to streamline its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->