### PR TITLE
:lock: mitigate a vulerability in one of the dependecies from Microsoft (Newtonsoft.Json)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Cuemon.Core" Version="9.0.0" />
@@ -21,6 +22,7 @@
     <PackageVersion Include="xunit.extensibility.core" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />


### PR DESCRIPTION
This pull request includes updates to the `Directory.Packages.props` file to enable a new feature and add a new package version.

Changes to package management:

* Enabled central package transitive pinning by adding the `<CentralPackageTransitivePinningEnabled>` property.

Updates to package versions:

* Added the `Newtonsoft.Json` package with version `13.0.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced transitive pinning for centrally managed package versions to enhance consistency across projects.
	- Added support for `Newtonsoft.Json` version `13.0.3`, improving JSON serialization and deserialization capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->