### PR TITLE
Ossf/gha scorecard

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -5,17 +5,15 @@ on:
     paths-ignore:
       - .codecov/**
       - .docfx/**
-      - .github/**
       - .nuget/**
-      - '**.md'
+      - '**/*.md'
   push:
     branches: [main]
     paths-ignore:
       - .codecov/**
       - .docfx/**
-      - .github/**
       - .nuget/**
-      - '**.md'
+      - '**/*.md'
   workflow_dispatch:
     inputs:
       configuration:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,14 +23,14 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to improve their functionality and compatibility. The most important changes include modifying file path patterns in the `pipelines.yml` file and updating action versions in the `scorecard.yml` file.

Updates to GitHub Actions workflows:

* [`.github/workflows/pipelines.yml`](diffhunk://#diff-c40697b077557a99813200fa892d01ac2d8c5201799193bc34320cd9526ee802L8-R16): Changed the file path pattern for markdown files to use `**/*.md` instead of `**.md` for better matching.
* [`.github/workflows/scorecard.yml`](diffhunk://#diff-2e3112f4e81a9c47df8000638ce3b1b9ca15edcc82b228c207a7a4ff3bc7133fL26-R33): Updated the `ossf/scorecard-action` to version `v2.4.0` and `actions/upload-artifact` to version `v4` to ensure compatibility with the latest features and improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated markdown file ignoring patterns in CI/CD workflows to include all subdirectory markdown files.
	- Removed ignore rules for the `.github/` directory in CI/CD triggers.
	- Upgraded action versions in the scorecard workflow for improved analysis and artifact handling.
	- Maintained the overall structure and logic of workflows without changes to job definitions or execution conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->