### PR TITLE
V9.1.2/compatibility fixes

### DIFF
--- a/.nuget/Codebelt.Extensions.Xunit.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.App/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.1.1
+﻿Version 9.1.2
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.1.1
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting.AspNetCore/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.1.1
+﻿Version 9.1.2
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.1.1
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
@@ -1,4 +1,13 @@
-﻿Version 9.1.1
+﻿Version 9.1.2
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+# Bug Fixes
+- FIXED HostTest class in the Codebelt.Extensions.Xunit.Hosting namespace to have same behavior as prior to 9.1.0 release (hereby being backward compatible as originally intended)
+ 
+Version 9.1.1
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.1.1
+﻿Version 9.1.2
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.1.1
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Xunit, Cuemon.Extensions.Xunit.Hosting, and Cuemon.Extensions.Xunit.Hosting.AspNetCore.
 
+## [9.1.2] - 2025-04-03
+
+### Fixed
+
+- HostTest class in the Codebelt.Extensions.Xunit.Hosting namespace to have same behavior as prior to `9.1.0` release (hereby being backward compatible as originally intended)
+  - Reintroduced `Configure` method to be virtual (brain fart; should have been captured with `9.1.1` release)
+
 ## [9.1.1] - 2025-04-01
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -71,7 +71,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.console" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Codebelt.Extensions.Xunit.Hosting/HostTest.cs
+++ b/src/Codebelt.Extensions.Xunit.Hosting/HostTest.cs
@@ -101,7 +101,7 @@ namespace Codebelt.Extensions.Xunit.Hosting
         /// </summary>
         /// <param name="configuration">The <see cref="IConfiguration"/> initialized by the <see cref="IHost"/>.</param>
         /// <param name="environment">The <see cref="IHostEnvironment"/> initialized by the <see cref="IHost"/>.</param>
-        public void Configure(IConfiguration configuration, IHostEnvironment environment)
+        public virtual void Configure(IConfiguration configuration, IHostEnvironment environment)
         {
             Configuration = configuration;
             HostingEnvironment = environment;

--- a/test/Codebelt.Extensions.Xunit.Tests/DisposableTest.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/DisposableTest.cs
@@ -81,8 +81,9 @@ namespace Codebelt.Extensions.Xunit
             }
             finally
             {
-                GC.Collect(0, GCCollectionMode.Forced);
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
                 GC.WaitForPendingFinalizers();
+                Task.Delay(500).Wait(); // Add a small delay
             }
 
             if (unmanaged.TryGetTarget(out var ud2))

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -4,12 +4,12 @@
         {
             "name": "WSL-Ubuntu",
             "type": "wsl",
-            "wslDistribution": "Ubuntu-22.04"
+            "wslDistribution": "Ubuntu-24.04"
         },
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.407-9.0.202"
+            "dockerImage": "gimlichael/ubuntu-testrunner:mono-net8.0.407-9.0.202"
         }
     ]
 }


### PR DESCRIPTION
This pull request includes updates to multiple package release notes, a change in the `CHANGELOG.md`, and several other modifications to improve compatibility and functionality. The most important changes include updates to dependencies, bug fixes, and configuration improvements.

### Bug Fixes:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R16): Documented the fix for the `HostTest` class to ensure backward compatibility with the reintroduction of the `Configure` method as virtual.
* [`src/Codebelt.Extensions.Xunit.Hosting/HostTest.cs`](diffhunk://#diff-306ff2a30f1c4b4b779555de4ef3b47de3c11ecf93ac31c60ddbe0fd0d1c5660L104-R104): Made the `Configure` method virtual to maintain backward compatibility.

### Configuration Improvements:

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL74-R77): Updated the `xunit.runner.visualstudio` package reference to include `PrivateAssets` and `IncludeAssets` attributes for better asset management.
* [`testenvironments.json`](diffhunk://#diff-9b8e96d74f58d1bbdcf7d7b724a15bd55082811dec8775f77cd16f909e898ec4L7-R12): Updated the WSL distribution to `Ubuntu-24.04` and the Docker image to `gimlichael/ubuntu-testrunner:mono-net8.0.407-9.0.202`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release notes to version 9.1.2, now reflecting enhanced platform availability (.NET 9, .NET 8, and .NET Standard 2.0) and refreshed dependency details.
- **Bug Fixes**
  - Restored host component behavior to ensure backward compatibility.
- **Tests**
  - Improved test conditions by refining garbage collection timing and introducing delays for resource finalization.
- **Chores**
  - Updated dependency management settings and modernized test environment configurations with newer distributions and Docker images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->