### PR TITLE
:construction_worker: utilize remainder of reusable workflow

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -23,109 +23,41 @@ permissions:
 
 jobs:
   build:
-    name: 🛠️ Build
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    name: call-build
     strategy:
       matrix:
         configuration: [Debug, Release]
-        framework: [net9.0,net8.0,netstandard2.0]
-    outputs:
-      version: ${{ steps.minver-calculate.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: codebeltnet/git-checkout@v1
-
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Install MinVer
-        uses: codebeltnet/dotnet-tool-install-minver@v1
-
-      - id: minver-calculate
-        name: Calculate Version
-        uses: codebeltnet/minver-calculate@v2
-
-      - name: Download xunit.snk file
-        uses: codebeltnet/gcp-download-file@v1
-        with:
-          serviceAccountKey: ${{ secrets.GCP_TOKEN }}
-          bucketName: ${{ secrets.GCP_BUCKETNAME }}
-          objectName: xunit.snk
-
-      - name: Set environment variable for projects
-        run: |
-          if [ "${{ matrix.framework }}" == "netstandard2.0" ]; then
-            projects=(
-              "src/**/Codebelt.Extensions.Xunit.csproj"
-              "src/**/Codebelt.Extensions.Xunit.Hosting.csproj"
-            )
-            echo "PROJECTS=$(IFS=' '; echo "${projects[*]}")" >> $GITHUB_ENV
-          else
-            echo "PROJECTS=src/**/*.csproj" >> $GITHUB_ENV
-          fi
-        shell: bash
-
-      - name: Restore Dependencies
-        uses: codebeltnet/dotnet-restore@v2
-
-      - name: Build for ${{ matrix.framework }} (${{ matrix.configuration }})
-        uses: codebeltnet/dotnet-build@v2
-        with:
-          projects: ${{ env.PROJECTS }}
-          configuration: ${{ matrix.configuration }}
-          framework: ${{ matrix.framework }}
+    uses: codebeltnet/jobs-dotnet-build/.github/workflows/default.yml@v1
+    with:
+      configuration: ${{ matrix.configuration }}
+      strong-name-key-filename: xunit.snk
+    secrets:
+      GCP_TOKEN: ${{ secrets.GCP_TOKEN }}
+      GCP_BUCKETNAME: ${{ secrets.GCP_BUCKETNAME }}
 
   pack:
-    name: 📦 Pack
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    name: call-pack
+    needs: [build]
     strategy:
       matrix:
         configuration: [Debug, Release]
-    needs: [build]
-    steps:
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Pack for ${{ matrix.configuration }}
-        uses: codebeltnet/dotnet-pack@v2
-        with:
-          configuration: ${{ matrix.configuration }}
-          uploadPackedArtifact: true
-          version: ${{ needs.build.outputs.version }}
+    uses: codebeltnet/jobs-dotnet-pack/.github/workflows/default.yml@v1
+    with:
+      configuration: ${{ matrix.configuration }}
+      upload-packed-artifact: true
+      version: ${{ needs.build.outputs.version }}
 
   test:
-    name: 🧪 Test
+    name: call-test
     needs: [build]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-24.04, windows-2022]
         configuration: [Debug, Release]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: codebeltnet/git-checkout@v1
-
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Install .NET Tool - Report Generator
-        uses: codebeltnet/dotnet-tool-install-reportgenerator@v1
-
-      - name: Test with ${{ matrix.configuration }} build
-        uses: codebeltnet/dotnet-test@v3
-        with:
-          configuration: ${{ matrix.configuration }}
-          buildSwitches: -p:SkipSignAssembly=true
+    uses: codebeltnet/jobs-dotnet-test/.github/workflows/default.yml@v1
+    with:
+      configuration: ${{ matrix.configuration }}
 
   sonarcloud:
     name: call-sonarcloud
@@ -154,16 +86,15 @@ jobs:
 
   deploy:
     if: github.event_name != 'pull_request'
-    name: 🚀 Deploy v${{ needs.build.outputs.version }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    name: call-nuget
     needs: [build, pack, test, sonarcloud, codecov, codeql]
-    environment: Production
+    uses: codebeltnet/jobs-nuget-push/.github/workflows/default.yml@v1
+    with:
+      version: ${{ needs.build.outputs.version }}
+      environment: Production
+      configuration: ${{ inputs.configuration == '' && 'Release' || inputs.configuration }}
     permissions:
       contents: write
       packages: write
-    steps:
-      - uses: codebeltnet/nuget-push@v1
-        with:
-          token: ${{ secrets.NUGET_TOKEN }}
-          configuration: ${{ inputs.configuration == '' && 'Release' || inputs.configuration }}
+    secrets:
+      NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -59,6 +59,7 @@ jobs:
     with:
       configuration: ${{ matrix.configuration }}
       runs-on: ${{ matrix.os }}
+      build-switches: -p:SkipSignAssembly=true
 
   sonarcloud:
     name: call-sonarcloud

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -58,6 +58,7 @@ jobs:
     uses: codebeltnet/jobs-dotnet-test/.github/workflows/default.yml@v1
     with:
       configuration: ${{ matrix.configuration }}
+      runs-on: ${{ matrix.os }}
 
   sonarcloud:
     name: call-sonarcloud


### PR DESCRIPTION
This pull request simplifies and modularizes the GitHub Actions workflow in `.github/workflows/pipelines.yml` by replacing custom job definitions with reusable workflows. The changes aim to improve maintainability and reduce duplication across the workflow file.

### Workflow Refactoring:

* **Build Job**: Replaced the custom `build` job with a reusable workflow from `codebeltnet/jobs-dotnet-build`. This includes defining inputs like `strong-name-key-filename` and secrets such as `GCP_TOKEN` and `GCP_BUCKETNAME`.
* **Pack Job**: Replaced the custom `pack` job with the reusable workflow `codebeltnet/jobs-dotnet-pack`. Inputs like `upload-packed-artifact` and the `version` from the `build` job's outputs are passed to the reusable workflow.
* **Test Job**: Replaced the custom `test` job with the reusable workflow `codebeltnet/jobs-dotnet-test`. Updated the matrix to include `ubuntu-24.04` instead of `ubuntu-22.04`.
* **Deploy Job**: Replaced the custom `deploy` job with the reusable workflow `codebeltnet/jobs-nuget-push`. Passed inputs like `version`, `environment`, and `configuration`, along with the `NUGET_TOKEN` secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined the build pipeline by switching to modular, reusable workflows for build, pack, test, and deploy steps.
	- Updated the test job to use a newer Ubuntu runner version.
- **Chores**
	- Simplified and centralized workflow logic for easier maintenance and improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->