### PR TITLE
v10.0.4/service update

### DIFF
--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -1,4 +1,6 @@
-﻿FROM --platform=$BUILDPLATFORM nginx:1.29.0-alpine AS base
+﻿ARG NGINX_VERSION=1.29.0-alpine
+
+FROM --platform=$BUILDPLATFORM nginx:${NGINX_VERSION} AS base
 RUN rm -rf /usr/share/nginx/html/*
 
 FROM --platform=$BUILDPLATFORM codebeltnet/docfx:2.78.3 AS build
@@ -8,7 +10,7 @@ ADD [".", "docfx"]
 RUN cd docfx; \
     docfx build
 
-FROM nginx:1.29.0-alpine AS final
+FROM nginx:${NGINX_VERSION} AS final
 WORKDIR /usr/share/nginx/html
 COPY --from=build /build/docfx/wwwroot /usr/share/nginx/html
 

--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -1,4 +1,4 @@
-﻿FROM --platform=$BUILDPLATFORM nginx:1.28.0-alpine AS base
+﻿FROM --platform=$BUILDPLATFORM nginx:1.29.0-alpine AS base
 RUN rm -rf /usr/share/nginx/html/*
 
 FROM --platform=$BUILDPLATFORM codebeltnet/docfx:2.78.3 AS build
@@ -8,7 +8,7 @@ ADD [".", "docfx"]
 RUN cd docfx; \
     docfx build
 
-FROM nginx:1.28.0-alpine AS final
+FROM nginx:1.29.0-alpine AS final
 WORKDIR /usr/share/nginx/html
 COPY --from=build /build/docfx/wwwroot /usr/share/nginx/html
 

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -64,7 +64,7 @@ jobs:
   sonarcloud:
     name: call-sonarcloud
     needs: [build,test]
-    uses: codebeltnet/jobs-sonarcloud/.github/workflows/default.yml@v1
+    uses: codebeltnet/jobs-sonarcloud/.github/workflows/default.yml@v2
     with:
       organization: geekle
       projectKey: xunit
@@ -82,7 +82,7 @@ jobs:
   codeql:
     name: call-codeql
     needs: [build,test]
-    uses: codebeltnet/jobs-codeql/.github/workflows/default.yml@v1
+    uses: codebeltnet/jobs-codeql/.github/workflows/default.yml@v2
     permissions:
       security-events: write
 

--- a/.nuget/Codebelt.Extensions.Xunit.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.App/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version 10.0.4
+Availability: .NET 9 and .NET 8
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 ﻿Version 10.0.3
 Availability: .NET 9 and .NET 8
  

--- a/.nuget/Codebelt.Extensions.Xunit.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.App/PackageReleaseNotes.txt
@@ -1,10 +1,10 @@
-Version 10.0.4
+﻿Version 10.0.4
 Availability: .NET 9 and .NET 8
 
 # ALM
 - CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
-
-﻿Version 10.0.3
+ 
+Version 10.0.3
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting.AspNetCore/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version 10.0.4
+Availability: .NET 9 and .NET 8
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 ﻿Version 10.0.3
 Availability: .NET 9 and .NET 8
  

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting.AspNetCore/PackageReleaseNotes.txt
@@ -1,10 +1,10 @@
-Version 10.0.4
+﻿Version 10.0.4
 Availability: .NET 9 and .NET 8
 
 # ALM
 - CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
-
-﻿Version 10.0.3
+ 
+Version 10.0.3
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version 10.0.4
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 ﻿Version 10.0.3
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
@@ -1,10 +1,10 @@
-Version 10.0.4
+﻿Version 10.0.4
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
 
 # ALM
 - CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
-
-﻿Version 10.0.3
+ 
+Version 10.0.3
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version 10.0.4
+Availability: .NET 9 and .NET 8
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
 ﻿Version 10.0.3
 Availability: .NET 9 and .NET 8
  

--- a/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
@@ -1,10 +1,10 @@
-Version 10.0.4
+﻿Version 10.0.4
 Availability: .NET 9 and .NET 8
 
 # ALM
 - CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
-
-﻿Version 10.0.3
+ 
+Version 10.0.3
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 For more details, please refer to `PackageReleaseNotes.txt` on a per assembly basis in the `.nuget` folder.
 
-## [10.0.4] - 2025-07-20
-
-This is a service update that focuses on package dependencies.
-
-### Changed
-
-- Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
-
 > [!NOTE]
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Xunit, Cuemon.Extensions.Xunit.Hosting, and Cuemon.Extensions.Xunit.Hosting.AspNetCore.
+
+## [10.0.4] - 2025-07-10
+
+This is a service update that focuses on package dependencies.
 
 ## [10.0.3] - 2025-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 For more details, please refer to `PackageReleaseNotes.txt` on a per assembly basis in the `.nuget` folder.
 
-> [!NOTE]  
+## [10.0.4] - 2025-07-20
+
+This is a service update that focuses on package dependencies.
+
+### Changed
+
+- Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+
+> [!NOTE]
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Xunit, Cuemon.Extensions.Xunit.Hosting, and Cuemon.Extensions.Xunit.Hosting.AspNetCore.
 
 ## [10.0.3] - 2025-06-15

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,10 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Cuemon.Core" Version="9.0.6" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.6" />
-    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.6" />
+    <PackageVersion Include="Cuemon.Core" Version="9.0.7" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.7" />
+    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="NativeLibraryLoader" Version="1.0.13" />
@@ -24,12 +24,12 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.7" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) OR $(TargetFramework.StartsWith('netstandard2'))">
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
@@ -37,6 +37,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
   </ItemGroup>
 </Project>

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.411-9.0.301"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.412-9.0.302"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- update dependencies
- bump Docker test image and nginx
- refresh changelog and release notes

## Testing
- `dotnet test -f net8.0` *(fails: NETSDK1045 due to missing .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68701db271c48330be3cdd6371694ced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated various dependencies to their latest compatible versions across all supported target frameworks.
  * Upgraded nginx version in the Docker environment.
  * Updated Docker test environment image tags.
  * Refreshed package release notes and changelog to reflect dependency updates and new version support (.NET 9 and .NET 8).
  * Updated GitHub Actions workflows to newer versions for improved CI/CD processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->