### PR TITLE
V10.0.6/service update

### DIFF
--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -1,4 +1,4 @@
-﻿ARG NGINX_VERSION=1.29.0-alpine
+﻿ARG NGINX_VERSION=1.29.1-alpine
 
 FROM --platform=$BUILDPLATFORM nginx:${NGINX_VERSION} AS base
 RUN rm -rf /usr/share/nginx/html/*

--- a/.nuget/Codebelt.Extensions.Xunit.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.App/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 10.0.5
+﻿Version 10.0.6
+Availability: .NET 9 and .NET 8
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 10.0.5
 Availability: .NET 9 and .NET 8
 
 # ALM

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting.AspNetCore/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 10.0.5
+﻿Version 10.0.6
+Availability: .NET 9 and .NET 8
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 10.0.5
 Availability: .NET 9 and .NET 8
 
 # ALM

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 10.0.5
+﻿Version 10.0.6
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 10.0.5
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
 
 # ALM

--- a/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 10.0.5
+﻿Version 10.0.6
+Availability: .NET 9 and .NET 8
+
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 10.0.5
 Availability: .NET 9 and .NET 8
 
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Xunit, Cuemon.Extensions.Xunit.Hosting, and Cuemon.Extensions.Xunit.Hosting.AspNetCore.
 
+## [10.0.6] - 2025-09-14
+
+This is a service update that focuses on package dependencies.
+
 ## [10.0.5] - 2025-08-16
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,10 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Cuemon.Core" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.8" />
+    <PackageVersion Include="Cuemon.Core" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="NativeLibraryLoader" Version="1.0.13" />
@@ -24,12 +24,12 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) OR $(TargetFramework.StartsWith('netstandard2'))">
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
@@ -37,6 +37,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.20" />
   </ItemGroup>
 </Project>

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.413-9.0.304"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.414-9.0.305"
         }
     ]
 }


### PR DESCRIPTION
This pull request is a service update focused on upgrading package dependencies across the project to their latest compatible versions. It also updates release notes and documentation to reflect these changes, and bumps the NGINX version in the Dockerfile.

**Dependency Updates:**

* Upgraded several core and extension package dependencies in `Directory.Packages.props`, including `Cuemon.Core`, `Cuemon.Extensions.AspNetCore`, `Cuemon.Extensions.IO`, `Microsoft.Bcl.AsyncInterfaces`, and various `Microsoft.Extensions.*` packages for .NET 9 and .NET 8 target frameworks. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L7-R10) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L27-R40)
* Updated the `Microsoft.AspNetCore.TestHost` package for .NET 8 and .NET Standard 2.0 targets.

**Release Notes and Documentation:**

* Updated release notes for version 10.0.6 in all relevant `PackageReleaseNotes.txt` files to indicate dependency upgrades and availability for supported frameworks. [[1]](diffhunk://#diff-653ee4b5737f9489f7a1940833a9b5d0bad4dc369f580453852a9b12de2e75b2L1-R7) [[2]](diffhunk://#diff-de141f55daca452e837f70664508846c20f24a9828a7382a25f9878ac73ed38eL1-R7) [[3]](diffhunk://#diff-cb0a6e43212a3dd2675529d0503e42ff256034597beb3bb2510d64408e97d2a0L1-R7) [[4]](diffhunk://#diff-60718283ae5601ae7fac124719fae2f509d4739c37f7486f9c7559d7bd6eaba9L1-R7)
* Added a new entry for version 10.0.6 in `CHANGELOG.md` describing this as a service update focused on package dependencies.

**Build and Test Environment:**

* Updated the NGINX base image version in `.docfx/Dockerfile.docfx` from `1.29.0-alpine` to `1.29.1-alpine`.
* Updated the Docker test environment image in `testenvironments.json` to use `gimlichael/ubuntu-testrunner:net8.0.414-9.0.305`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded platform and library dependencies to latest compatible versions (including Microsoft.Extensions, Cuemon, AsyncInterfaces).
  - Updated ASP.NET Core TestHost for .NET 8.
  - Refreshed Docker base image to NGINX 1.29.1-alpine.
  - Updated test runner Docker image to latest .NET 8/9 patch levels.

- Documentation
  - Added 10.0.6 release notes across packages (availability: .NET 9 and .NET 8; one also includes .NET Standard 2.0), noting dependency updates.
  - Updated CHANGELOG with 10.0.6 service update focused on dependency refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->