### PR TITLE
:alembic: xunit v3.2.0 (#3435)

### DIFF
--- a/.nuget/Codebelt.Extensions.Xunit.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.App/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version 11.0.1
+Availability: .NET 10 and .NET 9
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
 Version 11.0.0
 Availability: .NET 10 and .NET 9
  

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting.AspNetCore/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version 11.0.1
+Availability: .NET 10 and .NET 9
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
 Version 11.0.0
 Availability: .NET 10 and .NET 9
  

--- a/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version 11.0.1
+Availability: .NET 10, .NET 9 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
 Version 11.0.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
  

--- a/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Xunit/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version 11.0.1
+Availability: .NET 10 and .NET 9
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
 Version 11.0.0
 Availability: .NET 10 and .NET 9
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Xunit, Cuemon.Extensions.Xunit.Hosting, and Cuemon.Extensions.Xunit.Hosting.AspNetCore.
 
+## [11.0.1] - 2025-11-19
+
+This is a service update that focuses on package dependencies.
+
 ## [11.0.0] - 2025-11-11
 
 This is a major release that focuses on adapting to the latest .NET 10 (LTS) release, while also removing support for .NET 8 (LTS).

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,17 +4,17 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Cuemon.Core" Version="10.0.0-rc.2" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="10.0.0-rc.2" />
-    <PackageVersion Include="Cuemon.Extensions.IO" Version="10.0.0-rc.2" />
+    <PackageVersion Include="Cuemon.Core" Version="10.0.0" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="10.0.0" />
+    <PackageVersion Include="Cuemon.Extensions.IO" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="NativeLibraryLoader" Version="1.0.13" />
     <PackageVersion Include="Xunit.v3.Priority" Version="1.1.18" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
-    <PackageVersion Include="xunit.v3" Version="3.1.0" />
-    <PackageVersion Include="xunit.v3.assert" Version="3.1.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.0" />
+    <PackageVersion Include="xunit.v3.assert" Version="3.2.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.0" />
     <PackageVersion Include="xunit.v3.runner.console" Version="3.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
This pull request updates several package dependencies to newer stable versions in the `Directory.Packages.props` file. The main changes focus on moving from release candidate versions to final releases and updating the xUnit test framework to the latest version.

Dependency version updates:

* Updated `Cuemon.Core`, `Cuemon.Extensions.AspNetCore`, and `Cuemon.Extensions.IO` from version `10.0.0-rc.2` (release candidate) to the stable `10.0.0` release.
* Upgraded `xunit.v3` and `xunit.v3.assert` from version `3.1.0` to `3.2.0` (#3435).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded several framework packages from pre-release to stable releases.
  * Updated testing packages to their latest minor versions.

* **Documentation**
  * Added 11.0.1 release notes and changelog entry noting availability on .NET 10/9 (and .NET Standard 2.0 where applicable) and dependency alignment with current TFMs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->