### PR TITLE
✨ add macos support for test projects in build configuration

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
     <IsSourceProject>$(MSBuildProjectDirectory.ToLower().StartsWith('$(MSBuildThisFileDirectory.ToLower())src'))</IsSourceProject>
     <IsToolingProject>$(MSBuildProjectDirectory.ToLower().StartsWith('$(MSBuildThisFileDirectory.ToLower())tooling'))</IsToolingProject>
     <IsLinux>$([MSBuild]::IsOSPlatform('Linux'))</IsLinux>
+    <IsMacOS>$([MSBuild]::IsOSPlatform('OSX'))</IsMacOS>
     <IsWindows>$([MSBuild]::IsOSPlatform('Windows'))</IsWindows>
     <IsMainAuthor Condition="'$(EMAIL)' == 'michael@geekle.io'">true</IsMainAuthor>
     <SkipSignAssembly>false</SkipSignAssembly>
@@ -54,7 +55,7 @@
     <None Include="..\..\.nuget\$(MSBuildProjectName)\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(IsLinux)' == 'true'">
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND ('$(IsLinux)' == 'true' OR '$(IsMacOS)' == 'true')">
     <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
This pull request updates the build configuration to improve cross-platform support, specifically adding macOS detection and ensuring test projects target the correct frameworks on both Linux and macOS.

**Platform detection improvements:**

* Added a new property `IsMacOS` to detect when the build is running on macOS using MSBuild's `IsOSPlatform` method.

**Test project configuration:**

* Updated the condition for setting `TargetFrameworks` in test projects to include both Linux and macOS, so test projects now target `net10.0` and `net9.0` on either OS.