### PR TITLE
✅ add macOS platform support to disposable test assets

### DIFF
--- a/src/Codebelt.Extensions.Xunit.Hosting/HostFixture.cs
+++ b/src/Codebelt.Extensions.Xunit.Hosting/HostFixture.cs
@@ -119,7 +119,7 @@ public abstract class HostFixture : IHostFixture, IAsyncLifetime
     /// <summary>
     /// Called when this object is being disposed by <see cref="DisposeAsync()"/>.
     /// </summary>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
     protected virtual async ValueTask OnDisposeManagedResourcesAsync()
     {
         if (Host is IAsyncDisposable asyncDisposable)

--- a/test/Codebelt.Extensions.Xunit.Tests/Assets/AsyncDisposable.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/Assets/AsyncDisposable.cs
@@ -7,7 +7,7 @@ namespace Codebelt.Extensions.Xunit.Assets;
 public class AsyncDisposable : Test
 {
     IDisposable _disposableResource = new MemoryStream();
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
     IAsyncDisposable _asyncDisposableResource = new MemoryStream();
 #else
     IAsyncDisposable _asyncDisposableResource = new WemoryStream();

--- a/test/Codebelt.Extensions.Xunit.Tests/Assets/UnmanagedDisposable.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/Assets/UnmanagedDisposable.cs
@@ -28,7 +28,7 @@ public class UnmanagedDisposable : Test
 
     public UnmanagedDisposable()
     {
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             if (NativeLibrary.TryLoad("kernel32.dll", GetType().Assembly, DllImportSearchPath.System32, out _libHandle))
@@ -49,6 +49,13 @@ public class UnmanagedDisposable : Test
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             if (NativeLibrary.TryLoad("libc.so.6", GetType().Assembly, DllImportSearchPath.SafeDirectories, out _libHandle))
+            {
+                _handle = _libHandle; // i don't know of any native methods on unix
+            }
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            if (NativeLibrary.TryLoad("libSystem.B.dylib", GetType().Assembly, DllImportSearchPath.SafeDirectories, out _libHandle))
             {
                 _handle = _libHandle; // i don't know of any native methods on unix
             }
@@ -74,6 +81,12 @@ public class UnmanagedDisposable : Test
             _libHandle = _nativeLibrary.Handle;
             _handle = _libHandle; // i don't know of any native methods on unix
         }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            _nativeLibrary = new NativeLibrary("libSystem.B.dylib");
+            _libHandle = _nativeLibrary.Handle;
+            _handle = _libHandle; // i don't know of any native methods on unix
+        }
 #endif
     }
 
@@ -89,7 +102,7 @@ public class UnmanagedDisposable : Test
 
     protected override void OnDisposeUnmanagedResources()
     {
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             if (_handle != IntPtr.Zero)
@@ -106,6 +119,10 @@ public class UnmanagedDisposable : Test
         {
             NativeLibrary.Free(_libHandle);
         }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            NativeLibrary.Free(_libHandle);
+        }
 #else
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -118,6 +135,10 @@ public class UnmanagedDisposable : Test
             _nativeLibrary.Dispose();
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            _nativeLibrary.Dispose();
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             _nativeLibrary.Dispose();
         }

--- a/test/Codebelt.Extensions.Xunit.Tests/DisposableTest.cs
+++ b/test/Codebelt.Extensions.Xunit.Tests/DisposableTest.cs
@@ -11,7 +11,7 @@ public class DisposableTest : Test
     {
     }
 
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
     [Fact]
     public async Task AsyncDisposable_VerifyThatAssetIsBeingDisposed()
     {


### PR DESCRIPTION
Updates conditional compilation directives to align with NET9.0+ where macOS support is available. Adds macOS native library loading via libSystem.B.dylib in UnmanagedDisposable for both NET9+ and earlier TFM branches. Ensures platform-specific resource disposal tests work on macOS.